### PR TITLE
Fix Bluetooth hook type

### DIFF
--- a/hooks/useBluetooth.ts
+++ b/hooks/useBluetooth.ts
@@ -3,7 +3,7 @@ import { BleManager, Device } from 'react-native-ble-plx';
 import { Buffer } from 'buffer';
 
 export function useBluetooth() {
-  const managerRef = useRef<BleManager>();
+  const managerRef = useRef<BleManager | null>(null);
   const [devices, setDevices] = useState<Device[]>([]);
   const [connectedDevice, setConnectedDevice] = useState<Device | null>(null);
   const [isScanning, setIsScanning] = useState(false);


### PR DESCRIPTION
## Summary
- initialize `useRef` with `null` for `BleManager`
- install dependencies so tsconfig extends from Expo base without errors

## Testing
- `npm install`
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687c094d1b8883318e1c8bf4c836ef00